### PR TITLE
Added Composer support to Inchoo_SoapLogger module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "marko-m/inchoo_soaplogger",
+    "type": "magento-module",
+    "license": "OSL-3.0",
+    "description": "Magento extension for logging SOAP V1 and V2 API calls.",
+    "authors": [
+        {
+            "name": "Marko Martinović",
+            "email": "marko.martinovic@inchoo.net"
+        }
+    ]
+}


### PR DESCRIPTION
I've added support for use with Composer by adding a basic `composer.json` file to the root.